### PR TITLE
Add support for health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The deployed application can be viewed [here](https://www.jedsimson.co.nz/).
 
 - [gunicorn](https://gunicorn.org/)
 - [Docker](https://www.docker.com/)
-- [Heroku](https://www.heroku.com/)
+- [Render](https://www.render.com/)
 
 ## Development
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 from typing import Any, List, Callable
 
+from datetime import datetime, timezone
+
 import logging
 import os
 
@@ -169,6 +171,15 @@ def configure_monitoring(app: Flask) -> Flask:
     sentry.init(
         dsn=app.config['SENTRY_DSN'],
         integrations=[SentryFlaskIntegration()]
+    )
+
+    # Set up routes used for health checks
+    def ping():
+        return 'Pong @ {}'.format(datetime.now(timezone.utc))
+
+    app.add_url_rule(
+        rule='/ping',
+        view_func=ping
     )
 
     return app

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,3 +1,0 @@
-build:
-  docker:
-    web: Dockerfile


### PR DESCRIPTION
Adds a ping route to support health checks on [Render](https://www.render.com/).

```
➜ ~ curl 0.0.0.0:8000/ping
Pong @ 2022-05-28 06:51:51.063724+00:00%
```